### PR TITLE
Add io.giantswarm.application annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add `io.giantswarm.application.audience: all` annotation to publish the app to the customer Backstage catalog.
+- Migrate chart metadata annotations to `io.giantswarm.application.*` format.
+
 ## [1.0.2] - 2026-02-19
 
 ### Changed
@@ -25,49 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Not managing the CAPI taint anymore, it manages the `karpenter.sh/unregistered` karpenter taint that is applied by CAPI controllers when using a stale version for the patch request.
 
-## [0.6.0] - 2025-05-26
-
-### Changed
-
-- Update Go version in Dockerfile to 1.23.
-
-## [0.5.0] - 2025-05-22
-
-### Changed
-
-- Change node selector from `managed-by` to `karpenter.sh/registered`.
-
-## [0.4.0] - 2024-10-10
-
-### Changed
-
-- Allow all taints in the daemonset
-
-## [0.3.0] - 2024-03-19
-
-### Changed
-
-- Move to giantswarm catalog.
-
-## [0.2.0] - 2024-03-19
-
-### Added
-
-- Wait to receive signal to quit gracefully.
-
-## [0.1.0] - 2024-03-19
-
-### Added
-
-- First release.
-
 [Unreleased]: https://github.com/giantswarm/capa-karpenter-taint-remover/compare/v1.0.2...HEAD
 [1.0.2]: https://github.com/giantswarm/capa-karpenter-taint-remover/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/giantswarm/capa-karpenter-taint-remover/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/giantswarm/capa-karpenter-taint-remover/compare/v0.6.0...v1.0.0
-[0.6.0]: https://github.com/giantswarm/capa-karpenter-taint-remover/compare/v0.5.0...v0.6.0
-[0.5.0]: https://github.com/giantswarm/capa-karpenter-taint-remover/compare/v0.4.0...v0.5.0
-[0.4.0]: https://github.com/giantswarm/capa-karpenter-taint-remover/compare/v0.3.0...v0.4.0
-[0.3.0]: https://github.com/giantswarm/capa-karpenter-taint-remover/compare/v0.2.0...v0.3.0
-[0.2.0]: https://github.com/giantswarm/capa-karpenter-taint-remover/compare/v0.1.0...v0.2.0
-[0.1.0]: https://github.com/giantswarm/capa-karpenter-taint-remover/compare/v0.0.0...v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Not managing the CAPI taint anymore, it manages the `karpenter.sh/unregistered` karpenter taint that is applied by CAPI controllers when using a stale version for the patch request.
 
+## [0.6.0] - 2025-05-26
+
+### Changed
+
+- Update Go version in Dockerfile to 1.23.
+
+## [0.5.0] - 2025-05-22
+
+### Changed
+
+- Change node selector from `managed-by` to `karpenter.sh/registered`.
+
+## [0.4.0] - 2024-10-10
+
+### Changed
+
+- Allow all taints in the daemonset
+
+## [0.3.0] - 2024-03-19
+
+### Changed
+
+- Move to giantswarm catalog.
+
+## [0.2.0] - 2024-03-19
+
+### Added
+
+- Wait to receive signal to quit gracefully.
+
+## [0.1.0] - 2024-03-19
+
+### Added
+
+- First release.
+
 [Unreleased]: https://github.com/giantswarm/capa-karpenter-taint-remover/compare/v1.0.2...HEAD
 [1.0.2]: https://github.com/giantswarm/capa-karpenter-taint-remover/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/giantswarm/capa-karpenter-taint-remover/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/giantswarm/capa-karpenter-taint-remover/compare/v0.6.0...v1.0.0
+[0.6.0]: https://github.com/giantswarm/capa-karpenter-taint-remover/compare/v0.5.0...v0.6.0
+[0.5.0]: https://github.com/giantswarm/capa-karpenter-taint-remover/compare/v0.4.0...v0.5.0
+[0.4.0]: https://github.com/giantswarm/capa-karpenter-taint-remover/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/giantswarm/capa-karpenter-taint-remover/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/giantswarm/capa-karpenter-taint-remover/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/giantswarm/capa-karpenter-taint-remover/compare/v0.0.0...v0.1.0

--- a/helm/capa-karpenter-taint-remover/Chart.yaml
+++ b/helm/capa-karpenter-taint-remover/Chart.yaml
@@ -7,3 +7,6 @@ home: "https://github.com/giantswarm/capa-karpenter-taint-remover"
 icon: https://s.giantswarm.io/app-icons/giantswarm/1/dark.svg
 annotations:
   io.giantswarm.application.team: phoenix
+  io.giantswarm.application.audience: all
+  io.giantswarm.application.managed: "true"
+  io.giantswarm.application.restrictions.compatible-providers: "aws"


### PR DESCRIPTION
Add io.giantswarm.application.audience: all annotation and migrate chart metadata to io.giantswarm.application.* format.

Backstage is becoming the primary entry point for customers to discover apps. This app is part of the CAPA release (capa-karpenter-taint-remover) and should be customer-facing.

Relates to giantswarm/giantswarm#35731