### PR TITLE
Add VPA for karpenter-taint-remover DaemonSet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add VPA for `karpenter-taint-remover` DaemonSet with `updateMode: Initial`.
+
 ### Changed
 
 - Add `io.giantswarm.application.audience: all` annotation to publish the app to the customer Backstage catalog.

--- a/helm/capa-karpenter-taint-remover/templates/vpa.yaml
+++ b/helm/capa-karpenter-taint-remover/templates/vpa.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.verticalPodAutoscaler.enabled }}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  labels:
+  {{- include "labels.common" . | nindent 4 }}
+  name: {{ include "resource.default.name" . }}
+  namespace: {{ include "resource.default.namespace" . }}
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: DaemonSet
+    name: {{ include "resource.default.name" . }}
+  updatePolicy:
+    updateMode: Initial
+  resourcePolicy:
+    containerPolicies:
+    {{- toYaml .Values.verticalPodAutoscaler.containerPolicies | nindent 4 }}
+{{- end }}

--- a/helm/capa-karpenter-taint-remover/values.schema.json
+++ b/helm/capa-karpenter-taint-remover/values.schema.json
@@ -99,6 +99,17 @@
                     }
                 }
             }
+        },
+        "verticalPodAutoscaler": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "containerPolicies": {
+                    "type": "array"
+                }
+            }
         }
     }
 }

--- a/helm/capa-karpenter-taint-remover/values.yaml
+++ b/helm/capa-karpenter-taint-remover/values.yaml
@@ -23,3 +23,10 @@ resources:
     memory: 32Mi
   limits:
     memory: 64Mi
+
+verticalPodAutoscaler:
+  enabled: true
+  containerPolicies:
+    - containerName: karpenter-taint-remover
+      controlledValues: RequestsAndLimits
+      mode: Auto


### PR DESCRIPTION
## What

Adds a `VerticalPodAutoscaler` resource for the `karpenter-taint-remover` DaemonSet.

VPA is enabled by default (`verticalPodAutoscaler.enabled: true`) and can be disabled via values.

## Why

The engineering team identified `karpenter-taint-remover` as running without VPA on their production clusters during a resource usage assessment (2026-02-03). Tracked in giantswarm/giantswarm#35769.

## Mode

`updateMode: Initial` is used because `karpenter-taint-remover` is a DaemonSet. VPA cannot evict DaemonSet pods, so `Auto` mode would silently produce recommendations without ever applying them. `Initial` sets resources at pod creation time (e.g. on node roll or DaemonSet redeploy), which is correct and safe for DaemonSets.

## Changes

- `templates/vpa.yaml` — new file
- `values.yaml` — added `verticalPodAutoscaler` section with default container policies
- `values.schema.json` — schema for the new values