### PR TITLE
Build multi-arch (amd64 + arm64) container image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,10 @@ workflows:
   build:
     jobs:
     - architect/go-build:
-        name: go-build
+        matrix:
+          parameters:
+            architecture: ["linux/amd64", "linux/arm64"]
+        name: go-build-capa-karpenter-taint-remover-<<matrix.architecture>>
         context: architect
         binary: capa-karpenter-taint-remover
         filters:
@@ -17,8 +20,10 @@ workflows:
     - architect/push-to-registries:
         context: architect
         name: push-to-registries
+        multiarch: true
         requires:
-        - go-build
+        - go-build-capa-karpenter-taint-remover-linux/amd64
+        - go-build-capa-karpenter-taint-remover-linux/arm64
         filters:
           tags:
             only: /^v.*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Build and publish a multi-arch (linux/amd64 + linux/arm64) container image.
 - Add `io.giantswarm.application.audience: all` annotation to publish the app to the customer Backstage catalog.
 - Migrate chart metadata annotations to `io.giantswarm.application.*` format.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,11 @@
-# Build the manager binary
-FROM golang:1.26 AS builder
-
-WORKDIR /workspace
-# Copy the Go Modules manifests
-COPY go.mod go.mod
-COPY go.sum go.sum
-# cache deps before building and copying source so that we don't need to re-download as much
-# and so that source changes don't invalidate our downloaded layer
-RUN go mod download
-
-# Copy the go source
-COPY main.go main.go
-COPY internal/ internal/
-
-# Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o capa-karpenter-taint-remover main.go
-
-# Use distroless as minimal base image to package the manager binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
+# The binary is pre-built by architect/go-build in CircleCI (matrix over
+# linux/amd64 and linux/arm64) and persisted to the workspace as
+# capa-karpenter-taint-remover-linux-<arch>. docker buildx sets TARGETARCH
+# per platform; we copy the matching one into the image.
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
-COPY --from=builder /workspace/capa-karpenter-taint-remover .
+ARG TARGETARCH
+COPY capa-karpenter-taint-remover-linux-${TARGETARCH} /capa-karpenter-taint-remover
 USER 65532:65532
 
 ENTRYPOINT ["/capa-karpenter-taint-remover"]


### PR DESCRIPTION
Towards https://github.com/giantswarm/adidas/issues/1451

`capa-karpenter-taint-remover` is a DaemonSet that runs on every Karpenter-registered node (`nodeSelector: karpenter.sh/registered: "true"` + `tolerations: Exists`). Once customers add ARM64 Karpenter nodepools, the existing amd64-only image will crash with `exec format error`.

Changes:

- `architect/go-build` runs as a matrix over `linux/amd64` and `linux/arm64`. Produces `capa-karpenter-taint-remover-linux-{amd64,arm64}` in the workspace.
- `architect/push-to-registries` set to `multiarch: true`. Fan-in via explicit `requires` so the existing branch-protection check name (`go-build-capa-karpenter-taint-remover-...`) can be updated cleanly.
- Dockerfile: drop the in-Docker `golang:1.26` build stage (the architect orb already pre-builds the binary in the workspace — the previous Dockerfile was doing duplicate work). Switch to a single distroless stage that picks the right pre-built binary via `ARG TARGETARCH`.

Branch protection rules will need an update before merging:

- Remove: `ci/circleci: go-build`
- Add: `ci/circleci: go-build-capa-karpenter-taint-remover-linux/amd64`
- Add: `ci/circleci: go-build-capa-karpenter-taint-remover-linux/arm64`
